### PR TITLE
Make resilient to download counter API going down

### DIFF
--- a/components/DownloadCounter.vue
+++ b/components/DownloadCounter.vue
@@ -32,6 +32,9 @@ const { url } = defineProps({
 })
 
 const downloads = await fetch(url).then(result => {
+    if (!result.ok) {
+        throw new Error('Failed to fetch download count.')
+    }
     return result.json()
 }).then(jsonResult => {
     let downloadCount = jsonResult.value.toString();
@@ -39,5 +42,8 @@ const downloads = await fetch(url).then(result => {
         downloadCount = '0' + downloadCount;
     }
     return downloadCount;
+}).catch(error => {
+    console.error(error);
+    return '?????';
 })
 </script>

--- a/components/RomPatcherUi.vue
+++ b/components/RomPatcherUi.vue
@@ -303,9 +303,14 @@ function getSelectedVersion() {
 
 function incrementDownloadCounter() {
     fetch(COUNTER_URL).then(result => {
+        if (!result.ok) {
+            throw new Error('Failed to increment download counter');
+        }
         return result.json();
     }).then(jsonResult => {
         console.log('Download number: ' + jsonResult.value);
+    }).catch(error => {
+        console.error(error);
     });
 }
 


### PR DESCRIPTION
I forgot to add error handling here, apparently.