### PR TITLE
Add Giscus-powered comments to the blog posts

### DIFF
--- a/assets/social-links.json
+++ b/assets/social-links.json
@@ -88,10 +88,32 @@
         }
     },
     {
+        "locale": "pixelfed",
+        "icon": "fa6-solid:camera",
+        "link": "https://gram.social/i/web/profile/720046759473483704",
+        "color": "#00ADFB",
+        "display": {
+            "nav": false,
+            "row": true,
+            "stack": true
+        }
+    },
+    {
         "locale": "facebook",
         "icon": "fa6-brands:facebook",
         "link": "https://facebook.com/haroohie",
         "color": "#1877F2",
+        "display": {
+            "nav": false,
+            "row": true,
+            "stack": true
+        }
+    },
+    {
+        "locale": "pinterest",
+        "icon": "fa6-brands:pinterest",
+        "link": "https://pinterest.com/haroohie/",
+        "color": "#E71E3D",
         "display": {
             "nav": false,
             "row": true,

--- a/components/AuthorSocials.vue
+++ b/components/AuthorSocials.vue
@@ -4,7 +4,7 @@
             <IconifiedText icon="fa6-brands:x-twitter">{{ $t('twitter') }}</IconifiedText>
         </NuxtLink>
         <NuxtLink v-if="author.bluesky" :to="author.bluesky" rel="me">
-            <IconifiedText icon="fa6-solid:cloud">{{ $t('bluesky') }}</IconifiedText>
+            <IconifiedText icon="fa6-brands:bluesky">{{ $t('bluesky') }}</IconifiedText>
         </NuxtLink>
         <NuxtLink v-if="author.instagram" :to="author.instagram" rel="me">
             <IconifiedText icon="fa6-brands:instagram">{{ $t('instagram') }}</IconifiedText>

--- a/components/AuthorSocials.vue
+++ b/components/AuthorSocials.vue
@@ -18,6 +18,9 @@
         <NuxtLink v-if="author.mastodon" :to="author.mastodon" rel="me">
             <IconifiedText icon="fa6-brands:mastodon">{{ $t('mastodon') }}</IconifiedText>
         </NuxtLink>
+        <NuxtLink v-if="author.pixelfed" :to="author.pixelfed" rel="me">
+            <IconifiedText icon="fa6-solid:camera">{{ $t('pixelfed') }}</IconifiedText>
+        </NuxtLink>
         <NuxtLink v-if="author.youtube" :to="author.youtube" rel="me">
             <IconifiedText icon="fa6-brands:youtube">{{ $t('youtube') }}</IconifiedText>
         </NuxtLink>

--- a/components/content/GiscusComments.vue
+++ b/components/content/GiscusComments.vue
@@ -11,21 +11,23 @@ function fixupChineseLocale(locale) {
 </script>
 
 <template>
-    <Giscus
-        id="comments"
-        repo="haroohie-club/HaroohieSite"
-        repoId="R_kgDOG5Llsw"
-        category="Announcements"
-        categoryId="DIC_kwDOG5Lls84Cc20X"
-        mapping="specific"
-        :term="slug"
-        strict="1"
-        reactionsEnabled="1"
-        emitMetadata="0"
-        inputPosition="top"
-        theme="light"
-        :lang="fixupChineseLocale(lang)"
-    />
+    <div>
+        <Giscus
+            id="comments"
+            repo="haroohie-club/HaroohieSite"
+            repoId="R_kgDOG5Llsw"
+            category="Announcements"
+            categoryId="DIC_kwDOG5Lls84Cc20X"
+            mapping="specific"
+            :term="slug"
+            strict="1"
+            reactionsEnabled="1"
+            emitMetadata="0"
+            inputPosition="top"
+            theme="light"
+            :lang="fixupChineseLocale(lang)"
+        />
+    </div>
 </template>
 
 <script>

--- a/components/content/GiscusComments.vue
+++ b/components/content/GiscusComments.vue
@@ -1,0 +1,48 @@
+<script setup>
+function fixupChineseLocale(locale) {
+    if (locale == "zh-hans") {
+        return "zh-CN";
+    } else if (locale == "zh-hant") {
+        return "zh-TW";
+    } else {
+        return locale;
+    }
+}
+</script>
+
+<template>
+    <Giscus
+        id="comments"
+        repo="haroohie-club/HaroohieSite"
+        repoId="R_kgDOG5Llsw"
+        category="Announcements"
+        categoryId="DIC_kwDOG5Lls84Cc20X"
+        mapping="specific"
+        :term="slug"
+        strict="1"
+        reactionsEnabled="1"
+        emitMetadata="0"
+        inputPosition="top"
+        theme="light"
+        :lang="fixupChineseLocale(lang)"
+    />
+</template>
+
+<script>
+import Giscus from '@giscus/vue';
+
+export default {
+    components: { Giscus },
+    name: 'GiscusComments',
+    props: {
+        slug: {
+            type: String,
+            required: true,
+        },
+        lang: {
+            type: String,
+            required: true
+        }
+    }
+}
+</script>

--- a/components/content/SocialLinks.vue
+++ b/components/content/SocialLinks.vue
@@ -9,13 +9,13 @@
         <ButtonLink :link="localePath(stackTopper.link)" color="red" type="top-piece" :icon="stackTopper.icon" fullwidth>
             {{ $t(stackTopper.locale) }}
         </ButtonLink>
-        <ButtonLink v-for="social in socials.filter(s => s.display.row)" :icon="social.icon" :href="social.link" rel="me"
+        <ButtonLink v-for="social in socials.filter(s => s.display.row)" :icon="social.icon" :link="social.link" rel="me"
             :rgb-color="social.color" :type="socials.filter(s => s.display.row).indexOf(social) === (socials.filter(s => s.display.row).length - 1) ? 'bottom-piece' : 'mid-piece'" fullwidth>
             {{ $t(social.locale) }}
         </ButtonLink>
     </div>
     <ButtonRow v-else>
-        <ButtonLink v-for="social in socials.filter(s => s.display.row)" :icon="social.icon" :href="social.link" rel="me"
+        <ButtonLink v-for="social in socials.filter(s => s.display.row)" :icon="social.icon" :link="social.link" rel="me"
             :rgb-color="social.color">
             {{ $t(social.locale) }}
         </ButtonLink>

--- a/content/author/jonko/de.md
+++ b/content/author/jonko/de.md
@@ -2,11 +2,13 @@
 author:
   name: 'Jonko'
   github: 'https://github.com/jonko0493'
-  youtube: 'https://www.youtube.com/@jonko0493'
+  youtube: 'https://youtube.com/@jonko0493'
   twitter: 'https://twitter.com/jonko0493'
   bluesky: 'https://bsky.app/profile/jonko.bsky.social'
   mastodon: 'https://eldritch.cafe/@jonko'
   instagram: 'https://instagram.com/jonko0493'
+  threads: 'https://threads.net/@jonko0493'
+  pixelfed: 'https://gram.social/i/web/profile/720048688300269620'
 ---
 
 Jonko ist eine project lead and main ROM hacker for the Haroohie Translation Club.

--- a/content/author/jonko/en.md
+++ b/content/author/jonko/en.md
@@ -8,6 +8,7 @@ author:
   mastodon: 'https://eldritch.cafe/@jonko'
   instagram: 'https://instagram.com/jonko0493'
   threads: 'https://threads.net/@jonko0493'
+  pixelfed: 'https://gram.social/i/web/profile/720048688300269620'
 ---
 
 Jonko is the project lead and main ROM hacker for the Haroohie Translation Club.

--- a/content/author/jonko/it.md
+++ b/content/author/jonko/it.md
@@ -2,11 +2,13 @@
 author:
   name: 'Jonko'
   github: 'https://github.com/jonko0493'
-  youtube: 'https://www.youtube.com/@jonko0493'
+  youtube: 'https://youtube.com/@jonko0493'
   twitter: 'https://twitter.com/jonko0493'
   bluesky: 'https://bsky.app/profile/jonko.bsky.social'
   mastodon: 'https://eldritch.cafe/@jonko'
   instagram: 'https://instagram.com/jonko0493'
+  threads: 'https://threads.net/@jonko0493'
+  pixelfed: 'https://gram.social/i/web/profile/720048688300269620'
 ---
 
 Jonko è il capo progetto e il ROM hacker principale dell'Haroohie Translation Club.

--- a/content/author/jonko/zh-hans.md
+++ b/content/author/jonko/zh-hans.md
@@ -2,11 +2,13 @@
 author:
   name: 'Jonko'
   github: 'https://github.com/jonko0493'
-  youtube: 'https://www.youtube.com/@jonko0493'
+  youtube: 'https://youtube.com/@jonko0493'
   twitter: 'https://twitter.com/jonko0493'
   bluesky: 'https://bsky.app/profile/jonko.bsky.social'
   mastodon: 'https://eldritch.cafe/@jonko'
   instagram: 'https://instagram.com/jonko0493'
+  threads: 'https://threads.net/@jonko0493'
+  pixelfed: 'https://gram.social/i/web/profile/720048688300269620'
 ---
 
 Jonko 是 Haroohie Translation Club 的项目负责人和 ROM 的主要破解者。

--- a/giscus.json
+++ b/giscus.json
@@ -1,0 +1,3 @@
+{
+    "origins": ["https://haroohie.club"]
+}

--- a/layouts/blog.vue
+++ b/layouts/blog.vue
@@ -68,7 +68,7 @@ onMounted(() => {
 .blog {
     display: flex;
     flex-direction: column;
-    max-width: 1100px !important;
+    max-width: 935px !important;
     width: 61.5vw;
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -50,6 +50,8 @@
     "facebook": "Facebook",
     "tiktok": "TikTok",
     "threads": "Threads",
+    "pixelfed": "Pixelfed",
+    "pinterest": "Pinterest",
 
     "blogs": "Blogs",
     "back-to-blog": "Back to the Blog",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "hasInstallScript": true,
       "dependencies": {
+        "@giscus/vue": "^3.0.0",
         "nuxt-icon": "^0.4.2",
         "url-file-size": "^1.0.5-1",
         "vue-carousel": "^0.18.0",
@@ -1219,6 +1220,17 @@
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
       "dev": true
     },
+    "node_modules/@giscus/vue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@giscus/vue/-/vue-3.0.0.tgz",
+      "integrity": "sha512-ZoSUmlc3ee2a+kdumCaXFDZaB4h9b1BYWzsmmRP7zoGEQKYopdAnzGvJK7RdvrYGAzNqZtGUxI0NnBl8/UA6bQ==",
+      "dependencies": {
+        "giscus": "^1.5.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.0"
+      }
+    },
     "node_modules/@iconify-json/carbon": {
       "version": "1.1.30",
       "resolved": "https://registry.npmjs.org/@iconify-json/carbon/-/carbon-1.1.30.tgz",
@@ -1620,6 +1632,19 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
@@ -3389,6 +3414,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",
@@ -6848,6 +6878,14 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/giscus": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.5.0.tgz",
+      "integrity": "sha512-t3LL0qbSO3JXq3uyQeKpF5CegstGfKX/0gI6eDe1cmnI7D56R7j52yLdzw4pdKrg3VnufwCgCM3FDz7G1Qr6lg==",
+      "dependencies": {
+        "lit": "^3.1.2"
+      }
+    },
     "node_modules/git-config-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-2.0.0.tgz",
@@ -8072,6 +8110,34 @@
       "bin": {
         "listen": "bin/listhen.mjs",
         "listhen": "bin/listhen.mjs"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
+      "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
+      "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
+      "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/loader-runner": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sitemap": "^7.1.1"
   },
   "dependencies": {
+    "@giscus/vue": "^3.0.0",
     "nuxt-icon": "^0.4.2",
     "url-file-size": "^1.0.5-1",
     "vue-carousel": "^0.18.0",

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -37,8 +37,12 @@
                                     <ContentRenderer :value="doc.doc" />
                                 </i>
                                 <AuthorSocials :author="doc.doc.author" />
+                                <hr />
                             </template>
                         </ContentDoc>
+                    </div>
+                    <div id="giscus-comments">
+                        <GiscusComments :slug="route.params.slug" :lang="locale" />
                     </div>
                 </template>
                 <template #not-found>


### PR DESCRIPTION
The main thing this PR adds is [Giscus](https://giscus.app)-powered comments. To that end, the Giscus Vue component has been installed and a new custom component created that uses it. Rather than using the URL path, we feed Giscus the blog post's slug as its discussion term so that different locale versions of the same post don't have different comment sections. Additionally, I have added a `giscus.json` file to our repository root that will restrict Giscus to only running on haroohie.club.

Other quick changes in this PR:
* Add Haroohie Pixelfed and Pinterest to the socials stack 🤪 
* Switch to the actual Bluesky logo in the author socials component and add Pixelfed
* Fix warnings in the Social Links component caused by using `href` instead of `link`
* Fix a blog width issue (blog page ended up running over 1200px and throwing the entire layout out of alignment)