### PR TITLE
Scrolling image fix

### DIFF
--- a/components/ImageModal.vue
+++ b/components/ImageModal.vue
@@ -1,76 +1,85 @@
 <template>
-    <div class="overlay" @click="$emit('close-modal')">
-        <div class="modal">
-            <img v-if="imageSource" :src="imageSource" alt="image" />
-        </div>
+  <div class="overlay" @click="closeModal">
+    <div class="modal" @click.stop>
+      <img v-if="imageSource" :src="imageSource" alt="image" />
     </div>
+  </div>
 </template>
 
 <script setup>
-const { imageSource } = defineProps({
-    imageSource: {
-        type: String,
-        required: false
-    }
+const {imageSource} = defineProps({
+  imageSource: {
+    type: String,
+    required: false
+  }
 })
 
-const { emit } = defineEmits(['close-modal'])
-const showModal = ref(false)
+const emit = defineEmits(['close-modal'])
 
-watch(() => imageSource, () => {
-    showModal.value = true
-
-    document.body.style.overflow = 'hidden'
+onMounted(() => {
+  document.body.style.overflow = ''
+  document.body.classList.remove('modal-open')
+  document.body.classList.add('modal-open')
 })
 
+// Restore scroll when component unmounts
 onUnmounted(() => {
-    document.body.style.overflow = 'auto'
+  document.body.classList.remove('modal-open')
 })
+
+// Restore scroll when modal is closed via emit
+const closeModal = () => {
+  document.body.classList.remove('modal-open')
+  emit('close-modal')
+}
+
+
 </script>
 
 <style>
 article img:hover {
-    transform: scale(1.02);
-    filter: brightness(0.8);
-    cursor: pointer;
+  transform: scale(1.02);
+  filter: brightness(0.8);
+  cursor: pointer;
 }
 </style>
 
 <style scoped>
 .overlay {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: rgb(0, 0, 0, 0.65);
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgb(0, 0, 0, 0.65);
+  z-index: 1000;
 }
 
 .modal {
-    display: flex;
-    max-width: 70vw;
-    max-height: 85vh;
-    justify-content: center;
-    align-items: center;
-    margin: 0 auto;
+  display: flex;
+  max-width: 70vw;
+  max-height: 85vh;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
 }
 
 .modal img {
-    max-width: 100%;
-    max-height: 85vh;
-    height: 100%;
-    object-fit: fit-content !important;
-    box-shadow: var(--main-shadow);
+  max-width: 100%;
+  max-height: 85vh;
+  height: 100%;
+  object-fit: fit-content !important;
+  box-shadow: var(--main-shadow);
 }
 
 /* Less than 650px */
 @media screen and (max-width: 650px) {
-    .modal {
-        max-width: 90vw;
-        max-height: 90vh;
-    }
+  .modal {
+    max-width: 90vw;
+    max-height: 90vh;
+  }
 }
 </style>

--- a/components/ImageModal.vue
+++ b/components/ImageModal.vue
@@ -33,6 +33,20 @@ const closeModal = () => {
   emit('close-modal')
 }
 
+// Handle escape key
+onMounted(() => {
+  const handleEscape = (e) => {
+    if (e.key === 'Escape') {
+      closeModal()
+    }
+  }
+  document.addEventListener('keydown', handleEscape)
+
+  onUnmounted(() => {
+    document.removeEventListener('keydown', handleEscape)
+  })
+})
+
 
 </script>
 


### PR DESCRIPTION
**Issue:**
 When clicking an image to open the modal, document.body.style.overflow = 'hidden' is set but only restored in onUnmounted(). Since the modal component isn't destroyed when closed (just hidden), scroll remains disabled. Additionally, page reloads while modal is open leave the body with overflow: hidden permanently.

**Fix:**

- Restore scroll immediately when modal closes via the closeModal() function
- Clear any existing overflow styles on component mount to handle reload edge case
- Added escape key support and click-stop on modal content for better UX

Files changed: ImageModal.vue